### PR TITLE
Fixed affinity on/off setting

### DIFF
--- a/DDFacet/Other/AsyncProcessPool.py
+++ b/DDFacet/Other/AsyncProcessPool.py
@@ -273,7 +273,7 @@ class AsyncProcessPool (object):
             print("Parent and I/O affinities not specified, leaving unset", file=log)
         else:
             print(ModColor.Str("Fixing parent process to vthread %d" % self.parent_affinity, col="green"), file=log)
-        psutil.Process().cpu_affinity(range(self.ncpu) if not self.parent_affinity else [self.parent_affinity])
+            psutil.Process().cpu_affinity(range(self.ncpu) if not self.parent_affinity else [self.parent_affinity])
 
         # if NCPU is 0, set to number of CPUs on system
         if not self.ncpu:


### PR DESCRIPTION
There seems to be a bug in AsyncProcessPool.py where affinity is still being set when it is optionally turned off. 
Now affinity should turn off when told to.

I'm confident in this particular change however lines 827 and 828 may also need reviewing. I was strictly interested in turning affinity off altogether since DDFacet can't tell what CPUs are actually available in a slurm environment, which is problematic with affinity. So I commented those lines out too for good measure, but I'm not sure whether that is actually necessary so haven't included this in the pull request. Thought I'd provide these details for posterity.